### PR TITLE
Enforce failures globally

### DIFF
--- a/app/controllers/v1/tokens_controller.rb
+++ b/app/controllers/v1/tokens_controller.rb
@@ -5,7 +5,7 @@ module V1
     post :create, '/v1/tokens', 'Responds with a token' do
     end
     def create
-      render json: { token: Token.create(value: SecureRandom.hex).value }
+      render json: { token: Token.first_or_create(value: SecureRandom.hex).value }
     end
   end
 end


### PR DESCRIPTION
Doing this by not issuing new tokens on each request and
eventually, apps will get failures even if they cache
the original response for the token